### PR TITLE
Update package entry paths to match build output structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.1",
   "description": "Organize and de-identify DICOM header data ",
   "type": "module",
-  "main": "dist/esm/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "dist/esm/src/index.js",
+  "module": "dist/esm/src/index.js",
+  "types": "dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "types": "./dist/types/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "default": "./dist/esm/src/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Updated paths in package.json to correctly point to the actual file locations in the dist directory:
- Fixed main and module paths to point to dist/esm/src/index.js
- Updated types path to point to dist/types/src/index.d.ts
- Added types entry to exports field for proper TypeScript resolution

This resolves the "Failed to resolve entry for package 'dcm-organize'" error when building the UI project.